### PR TITLE
Update: Adds functionality for kube v1.16+ 

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This Pod runs in the `kube-system` namespace on k8s master nodes.
 
 ### Requirements
 
-- The virtual host in RabbitMQ for queues has to be `/`.
+- The virtual host in RabbitMQ for queues has to start with `/`, ie `/vhost_name`.
 - Namespace(s), deployment(s) or queue(s) defined in `AUTOSCALING` env var can't have `|` or `;` symbols in name(s).
 
 ### Env vars

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ This Pod runs in the `kube-system` namespace on k8s master nodes.
 - `RABBIT_USER`: Username used for authentication with the RabbitMQ API (check `deploy.yml`, defaults to `rabbit-pod-autoscaler` secret, `rabbit-user` key)
 - `RABBIT_PASS`: Password used for authentication with the RabbitMQ API (check `deploy.yml`, defaults to `rabbit-pod-autoscaler` secret, `rabbit-pass` key)
 - `AUTOSCALING`: Contains min/max pods, messages handled per pod, deployment info and queue name in the following pattern:
-  - single deployment to autoscale: `<minPods>|<maxPods>|<mesgPerPod>|<k8s namespace>|<k8s deployment name>|<RabbitMQ queue name>`
-    - e.g. `3|10|5|development|example|example.queue`
+  - single deployment to autoscale: `<minPods>|<maxPods>|<mesgPerPod>|<k8s namespace>|<k8s deployment name>|<RabbitMQ queue name>|<RabbitMQ vhost name>`
+    - e.g. `3|10|5|development|example|example.queue|rabbitmq.vhost`
     - `mesgPerPod` represents the amount of RabbitMQ messages a Pod can process within the `INTERVAL` (env var). As an example, if a Pod needs 6s to process a message from RabbitMQ, the `mesgPerPod` value will be `INTERVAL (30s) / process time (6s) = 5`.
   - multiple deployments to autoscale: check example `deploy.yml`
 - `LOGS`: Logging and Slack notifications intensity. Errors are logged and notified on every option

--- a/README.md
+++ b/README.md
@@ -33,5 +33,5 @@ This Pod runs in the `kube-system` namespace on k8s master nodes.
 ### Deployment
 
 ```
-kubectl --context CONTEXT -n kube-system apply -f deploy.yml
+kubectl -n kube-system apply -f deploy.yml
 ```

--- a/autoscale.sh
+++ b/autoscale.sh
@@ -33,10 +33,12 @@ IFS=';' read -ra autoscalingArr <<< "$autoscalingNoWS"
 
 while true; do
   for autoscaler in "${autoscalingArr[@]}"; do
-    IFS='|' read minPods maxPods mesgPerPod namespace deployment queueName <<< "$autoscaler"
+    IFS='|' read minPods maxPods mesgPerPod namespace deployment queueName vhostName <<< "$autoscaler"
+
+    vhostName=${vhostName:-"%2f"}
 
     queueMessagesJson=$(curl -s -S --retry 3 --retry-delay 3 -u "$RABBIT_USER:$RABBIT_PASS" \
-      $RABBIT_HOST:15672/api/queues/%2f/$queueName)
+      $RABBIT_HOST:15672/api/queues/%2f$vhostName/$queueName)
 
     if [[ $? -eq 0 ]]; then
       queueMessages=$(echo $queueMessagesJson | jq '.messages')

--- a/deploy.yml
+++ b/deploy.yml
@@ -70,8 +70,8 @@ spec:
                   key: rabbit-pass
             - name: AUTOSCALING
               value: >
-                3|10|5|development|example|example.queue;
-                3|5|3|development|example2|example2.queue
+                3|10|5|development|example|example.queue|vhost;
+                3|5|3|development|example2|example2.queue|vhost
             - name: LOGS
               value: HIGH
             - name: SLACK_HOOK

--- a/deploy.yml
+++ b/deploy.yml
@@ -27,23 +27,21 @@ subjects:
     name: rabbit-pod-autoscaler
     namespace: kube-system
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: rabbit-pod-autoscaler
   namespace: kube-system
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: rabbit-pod-autoscaler
   template:
     metadata:
       labels:
         app: rabbit-pod-autoscaler
     spec:
-      nodeSelector:
-        kubernetes.io/role: master
-      tolerations:
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
       serviceAccountName: rabbit-pod-autoscaler
       containers:
         - name: rabbit-pod-autoscaler


### PR DESCRIPTION
Feeding off the update from @swindi-de, where all the credit for vhost configuration goes to.
This adds support for versioning 1.16+ including selector label matching